### PR TITLE
update readme.adoc with required libs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,6 +13,20 @@ image:https://img.shields.io/github/license/i-Cell-Mobilsoft-Open-Source/icell-d
 npm i _@i-cell/data-table_
 ----
 
+## Requirements
+
+The table supports `Angular v11.1.0` currently. 
+
+In order to use the table, you need to install these dependencies: 
+|===
+| Package | Command to install | Current version |
+| Angular material |  `npm i @angular/material` |   11.1.0 |
+| Angular CDK | `npm i @angular/cdk`  | 11.1.0 |
+| ngx-trasnalte | `npm i ngx-translate` | 13.0.0 |
+| ngx-webstorage | `npm i ngx-webstorage` | 6.0.0 |
+|===
+
+
 == Usage
 
 === Configuration

--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ In order to use the table, you need to install these dependencies:
 | Package | Command to install | Current version |
 | Angular material |  `npm i @angular/material` |   11.1.0 |
 | Angular CDK | `npm i @angular/cdk`  | 11.1.0 |
-| ngx-trasnalte | `npm i ngx-translate` | 13.0.0 |
+| ngx-translate | `npm i ngx-translate` | 13.0.0 |
 | ngx-webstorage | `npm i ngx-webstorage` | 6.0.0 |
 |===
 


### PR DESCRIPTION
In my experience, these tools are required to properly import the table to an app.

Without those, errors will arise during compile (if the module is imported), for instance, without @angular/material and @angular/cdk:
```
Error: The target entry-point "@i-cell/data-table" has missing dependencies:
 - @angular/material/paginator
 - @angular/cdk/a11y
 - @angular/cdk/coercion
 - @angular/cdk/collections
 - @angular/material/sort
 - @angular/material/table
 - @angular/cdk/drag-drop
 - @angular/material/autocomplete
 - @angular/material/button
 - @angular/material/checkbox
 - @angular/material/datepicker
 - @angular/material/divider
 - @angular/material/icon
 - @angular/material/input
 - @angular/material/menu
 - @angular/material/progress-spinner
 - @angular/material/select
 - @angular/material/tooltip
 - @angular/material/core
 - @angular/cdk/table

```