### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,12 +20,29 @@ The table supports `Angular v11.1.0` currently.
 In order to use the table, you need to install these dependencies: 
 |===
 | Package | Command to install | Current version |
-| Angular material |  `npm i @angular/material` |   11.1.0 |
+| Angular material * |  `npm i @angular/material` |   11.1.0 |
 | Angular CDK | `npm i @angular/cdk`  | 11.1.0 |
 | ngx-translate | `npm i ngx-translate` | 13.0.0 |
 | ngx-webstorage | `npm i ngx-webstorage` | 6.0.0 |
 |===
 
+*if you need to add Angular Material to an existing project, make sure to load the required material palettes in your `styles.scss` for the Material theme as well. For example:
+```
+@import '~@angular/material/theming';
+
+@include mat-core();
+$candy-app-primary: mat-palette($mat-deep-purple);
+$candy-app-accent: mat-palette($mat-pink, A200, A100, A400);
+$candy-app-warn: mat-palette($mat-red);
+
+$candy-app-theme: mat-light-theme(
+    $candy-app-primary,
+    $candy-app-accent,
+    $candy-app-warn
+);
+
+@include angular-material-theme($candy-app-theme);
+```
 
 == Usage
 


### PR DESCRIPTION
To work properly when being added to an existing project (so one *without* angular material enabled at creation time) the table needs to have material theme palettes inserted to display the elements correctly.