### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,7 @@ NOTE: If you structure your `assets/` folder in a specific way, you have the opt
 
 [source, typescript, subs="verbatim,quotes"]
 ----
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DataTableModule } from '@icell/widget-data-table';
 import { MatTableModule } from '@angular/material/table';
 import { TranslateModule } from '@ngx-translate/core';
@@ -49,6 +50,7 @@ const pathToSvg: string = 'assets/path-to-svg/mdi.svg';
   ...
   imports: [
     ...
+    BrowserAnimationsModule
     *DataTableModule.forRoot(pathToSvg),*
     MatTableModule,
     TranslateModule.forRoot(),


### PR DESCRIPTION
Without `BrowserAnimationsModule`, the table won't render properly:

```
Error: Found the synthetic property @detailExpand. Please include either "BrowserAnimationsModule" or "NoopAnimationsModule" in your application.
    at checkNoSyntheticProp (platform-browser.js:778)
    at DefaultDomRenderer2.setProperty (platform-browser.js:760)
    at elementPropertyInternal (core.js:9924)
    at Module.ɵɵproperty (core.js:14654)
    at DataTableComponent_td_23_Template (i-cell-data-table.js:347)
```