### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -310,8 +310,7 @@ Delete the one line (`//registry.npmjs.org/:_authToken=${NPM_TOKEN}`) from `.npm
 
 [source, bash]
 ----
-# Build a local version
-npm run build:prod
+# Build and pack a local version
 npm run pack
 # Switch directories
 cd ./examples/icell-data-table-example/


### PR DESCRIPTION
`npm run pack` also runs `ng build:prod`, so it's necessary to run that command twice.