### PR TITLE
Removed icell-nexus reference from package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@i-cell/data-table",
-  "version": "2.0.2-beta.0",
+  "version": "2.0.3-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8406,7 +8406,7 @@
     },
     "ng-dynamic-component": {
       "version": "8.0.1",
-      "resolved": "https://nexus.icellmobilsoft.hu/repository/npm_public/ng-dynamic-component/-/ng-dynamic-component-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ng-dynamic-component/-/ng-dynamic-component-8.0.1.tgz",
       "integrity": "sha512-Ak25QTYmjNVxyZ6ywqRDDjoqAJheFeK0XoHsomwVjdHSiLoQcGfNNj5z51pqoRGpjdDZMSV+J2gaCbRNBeiy3g==",
       "requires": {
         "tslib": "^2.0.0"


### PR DESCRIPTION
Replaced the private repository link in the `package-lock.json`. 