### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -159,7 +159,7 @@ this.columnSettings: DataTableColumnDefinition[] = [
   },
   {
     label: 'weight',
-    valueGetter: (item) => (item.type === 'NET' ? item.netWeight : item.grossWeight)
+    valueGetter: (item) => (item.data.type === 'NET' ? item.netWeight : item.grossWeight)
     template: 'numericTemplate',
     sortable: true,
     hideable: true,


### PR DESCRIPTION
The valuegetter receives a row model, not the exact data.
![image](https://user-images.githubusercontent.com/10611667/117154379-12744a00-adbc-11eb-8079-6928055e5853.png)